### PR TITLE
Fix bug for multiple types in simpleFormUIFactory

### DIFF
--- a/R/simpleFormUIFactory.R
+++ b/R/simpleFormUIFactory.R
@@ -25,11 +25,11 @@ simpleFormUIFactory <- function(dao) {
         ns <- NS(id)
         widgets <- map(names(attributes), function(name) {
             a <- attributes[[name]]
-            if (a$type == 'factor') {
+            if ('factor' %in% a$type) {
                 selectInput(ns(name), name, choices = a$levels)
-            } else if (a$type == 'numeric') {
+            } else if ('numeric' %in% a$type) {
                 numericInput(ns(name), name, value = NA)
-            } else if (a$type == 'logical') {
+            } else if ('logical' %in% a$type) {
                 checkboxInput(ns(name), name)
             } else {
                 textInput(ns(name), name, value = NA)


### PR DESCRIPTION
`attributeType` assigns **all** classes of an object to the  `type` slot. In the case of an ordered factor it stores thus `factor` **and** `ordered`. In `simpleFormUIFactory` we are testing for the type via `==`. As of `R 4.2.0` using conditions of length greater than 1 will throw an error (used to be a warning before). That is, if we have any object with severeal classes (for instance an  `ordered` factor), the use of `==` will cause an error.

An easy fix is to replace `==` by `%in%` to make sure that the condition will always be of length one.

This closes #5.